### PR TITLE
Move some config to env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Set the `GITHUB_USER_TOKEN` environment variable to `your-user-token`
 
 (Optional) Set the `AUTOMERGE_LABEL` environment variable with whatever label you're using to automerge. By default `Automerge` will be used.
 
-Replace the placeholders in the [config.yml](https://github.com/MclaughlinSteve/automerge-kt/blob/master/src/main/resources/config.yml) with the information relative to your project (i.e. the url to as many repos as you want to run it across).
+Replace the placeholders in the [config.yml](src/main/resources/config.yml) with the information relative to your project (i.e. the url to as many repos as you want to run it across).
 
-Also, if you want to change the rate that it runs, update the `INTERVAL` constant in [Main.kt](https://github.com/MclaughlinSteve/automerge-kt/blob/master/src/main/kotlin/Main.kt).
+Also, if you want to change the rate that it runs, update the `INTERVAL` constant in [Main.kt](src/main/kotlin/Main.kt).
 
 ## Running it
 `gradle run`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 Automatically update and merge all github pull requests (PRs) in the repo with the `Automerge` label from oldest to newest.
 
 ## Configuration
-Replace the placeholders in the [config.yml](https://github.com/MclaughlinSteve/automerge-kt/blob/master/src/main/resources/config.yml) with the information relative to your project (i.e. add a github token, the label that you want to use for automerging, and the url to as many repos as you want to run it across).
+Set the `GITHUB_USER_TOKEN` environment variable to `your-user-token`
+
+(Optional) Set the `AUTOMERGE_LABEL` environment variable with whatever label you're using to automerge. By default `Automerge` will be used.
+
+Replace the placeholders in the [config.yml](https://github.com/MclaughlinSteve/automerge-kt/blob/master/src/main/resources/config.yml) with the information relative to your project (i.e. the url to as many repos as you want to run it across).
 
 Also, if you want to change the rate that it runs, update the `INTERVAL` constant in [Main.kt](https://github.com/MclaughlinSteve/automerge-kt/blob/master/src/main/kotlin/Main.kt).
 

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -7,12 +7,15 @@ fun loadGithubConfig(): List<GithubConfig> {
     val mapper = ObjectMapper(YAMLFactory())
     mapper.registerModule(KotlinModule())
 
-    val (basic, label, repos) = FileInputStream("${System.getProperty("user.dir")}/src/main/resources/config.yml").use {
+    val basic = System.getenv("GITHUB_USER_TOKEN") ?: throw Exception("Missing GITHUB_USER_TOKEN env variable")
+    val label = System.getenv("AUTOMERGE_LABEL") ?: "Automerge"
+
+    val ( repos ) = FileInputStream("${System.getProperty("user.dir")}/src/main/resources/config.yml").use {
         mapper.readValue(it, ConfigDto::class.java)
     }
 
     val headers: Map<String, String> = mapOf(
-            "authorization" to basic,
+            "authorization" to "Bearer $basic",
             "accept" to "application/vnd.github.v3+json, application/vnd.github.antiope-preview+json",
             "content-type" to "application/json")
 
@@ -28,7 +31,5 @@ data class GithubConfig(
 )
 
 data class ConfigDto(
-        val basic: String,
-        val label: String,
         val repos: List<String>
 )

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,3 @@
-basic: Basic your-auth-token
-label: your-automerge-label
 repos:
 - https://api.github.com/repos/org-name/your-repo-name
 - https://api.github.com/repos/org-name/your-other-repo-name


### PR DESCRIPTION
Closes #21 
Closes #23 

Moved token and automerge label to environment variables. It will use `Automerge` by default if another label is not specified. Also, it will throw an exception on startup if the token is not set.