### PR TITLE
Status check updates

### DIFF
--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -34,8 +34,8 @@ If none of those seem like the problem, try looking at the logs for more informa
 const val LABEL_REMOVAL_STATUS_CHECKS = """
 Uh oh! It looks like there was a problem trying to automerge this pull request.
 
-It seems likely that this is due to a cancelled or failing status check. Take a look at your statuses and get
-them passing before reapplying the automerge label.
+It seems likely that this is due to a cancelled or failing status check. Take a look at your statuses and
+ get them passing before reapplying the automerge label.
 """
 
 const val LABEL_REMOVAL_MERGE_CONFLICTS = """
@@ -268,10 +268,7 @@ class GithubService(config: GithubConfig) {
      * @param conclusion the conclusion for the check-run provided by github
      */
     private fun checkFailure(conclusion: String?) =
-            conclusion == "failure" ||
-                    conclusion == "action_required" ||
-                    conclusion == "cancelled" ||
-                    conclusion == "timed_out"
+            listOf("failure", "action_required", "cancelled", "timed_out").contains(conclusion)
 
     /**
      * Check if all "check-runs" are completed.

--- a/src/main/kotlin/GithubModels.kt
+++ b/src/main/kotlin/GithubModels.kt
@@ -38,12 +38,40 @@ data class StatusCheck(
 /**
  * Data class used to represent information about github's checks (e.g. travis status checks)
  * @property count the number of checks for a given pull request
- * @property checkRuns a lit of status checks that have or are being run
+ * @property checkRuns a list of status checks that have or are being run
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Check(
     @JsonProperty("total_count") val count: Int,
     @JsonProperty("check_runs") val checkRuns: List<StatusCheck>
+)
+
+/**
+ * Data class used to represent information about a github status
+ * (Note: description and context may not need to be nullable)
+ * @property state the state of the status ("success", "pending", "failure", or "error"
+ * @property description A short description of the status
+ * @property context A string label to differentiate this status from the status of other systems
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class StatusItem(
+    val state: String,
+    val description: String?,
+    val context: String?
+)
+
+/**
+ * Data class used to represent information about a github status summary. It has a roll-up of information
+ * about all of the statuses for a particular pull request
+ * @property state the state of the statuses
+ * @property count the number of statuses for a given pull request
+ * @property statuses a list of statuses that have or are being run
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Status(
+    val state: String,
+    @JsonProperty("total_count") val count: Int,
+    val statuses: List<StatusItem>
 )
 
 /**

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -60,7 +60,7 @@ private fun executeAutomerge(service: GithubService) {
         when (reviewStatus) {
             MergeState.CLEAN -> service.squashMerge(pull)
             MergeState.BEHIND -> service.updateBranch(pull)
-            MergeState.BLOCKED -> service.assessStatusChecks(pull)
+            MergeState.BLOCKED -> service.assessStatusAndChecks(pull)
             MergeState.UNMERGEABLE -> service.removeLabel(pull, LabelRemovalReason.MERGE_CONFLICTS)
             MergeState.BAD -> service.removeLabel(pull)
             MergeState.WAITING -> Unit // Do nothing


### PR DESCRIPTION
Closes: #17 

Update status checking to be more general. Now we're checking for both check-runs as well as statuses. This should make this much more usable overall. 