### PR TITLE
Priority label

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,18 @@ Automatically update and merge all github pull requests (PRs) in the specified r
 ## Configuration
 Set the `GITHUB_USER_TOKEN` environment variable to `your-user-token`
 
-(Optional) Set the `AUTOMERGE_LABEL` environment variable with whatever label you're using to automerge. By default `Automerge` will be used.
+(Optional) Set the `AUTOMERGE_LABEL` environment variable with whatever label you're using to automerge. 
+By default `Automerge` will be used.
 
-Replace the repository url in the [config.yml](src/main/resources/config.yml) with the information relative to your project (i.e. the urls to as many repos as you want to run it across).
+(Optional) Set the `PRIORITY_LABEL` environment variable with whatever label you're using for tagging something as 
+high priority. By default `Priority` will be used. The `Priority` label allows a PR with the `Automerge` label to
+take precedence in the merge order rather than merging from the oldest to newest.
 
-__For local running only__: If you want to change the rate that it runs, update the `INTERVAL` constant in [Main.kt](src/main/kotlin/Main.kt).
+Replace the repository url in the [config.yml](src/main/resources/config.yml) with the information relative to your 
+project (i.e. the urls to as many repos as you want to run it across).
+
+__For local running only__: If you want to change the rate that it runs, update the `INTERVAL` constant in 
+[Main.kt](src/main/kotlin/Main.kt).
 Note: This does not apply for running the job on AWS.
 
 ## Running it
@@ -36,7 +43,8 @@ Optional: Set the project to run on a periodic basis
 
 It runs on an interval against the repositories specified in the config, and for each repository
 it runs the following asynchronously (so that it can run all of the specified repositories in parallel):
-- Finds the oldest PR with the `Automerge` label on it
+- Finds the oldest PR with the `Automerge` label on it (Or if there is a PR with both `Automerge` and `Priority` 
+    it will grab the oldest PR with both of those labels)
 - If that PR has merge conflicts or a github status has failed (e.g. CI check failure or no approvals), 
     the label on that PR is removed, and a comment is left on the PR with a guess about why the label was removed.
 - If that PR still has outstanding github statuses (that is, they are currently still running), 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Set the `GITHUB_USER_TOKEN` environment variable to `your-user-token`
 By default `Automerge` will be used.
 
 (Optional) Set the `PRIORITY_LABEL` environment variable with whatever label you're using for tagging something as 
-high priority. By default `Priority` will be used. The `Priority` label allows a PR with the `Automerge` label to
-take precedence in the merge order rather than merging from the oldest to newest.
+high priority. By default `Priority Automerge` will be used. The `Priority Automerge` label allows a PR to
+take precedence in the merge order.
 
 Replace the repository url in the [config.yml](src/main/resources/config.yml) with the information relative to your 
 project (i.e. the urls to as many repos as you want to run it across).
@@ -43,8 +43,8 @@ Optional: Set the project to run on a periodic basis
 
 It runs on an interval against the repositories specified in the config, and for each repository
 it runs the following asynchronously (so that it can run all of the specified repositories in parallel):
-- Finds the oldest PR with the `Automerge` label on it (Or if there is a PR with both `Automerge` and `Priority` 
-    it will grab the oldest PR with both of those labels)
+- Finds the oldest PR with the `Automerge` label on it (Or if there is a PR with the `Priority Automerge` label,
+    it will grab the oldest PR with that label instead)
 - If that PR has merge conflicts or a github status has failed (e.g. CI check failure or no approvals), 
     the label on that PR is removed, and a comment is left on the PR with a guess about why the label was removed.
 - If that PR still has outstanding github statuses (that is, they are currently still running), 

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -8,6 +8,7 @@ fun loadGithubConfig(): List<GithubConfig> {
 
     val basic = System.getenv("GITHUB_USER_TOKEN") ?: throw Exception("Missing GITHUB_USER_TOKEN env variable")
     val label = System.getenv("AUTOMERGE_LABEL") ?: "Automerge"
+    val priority = System.getenv("PRIORITY_LABEL") ?: "Priority"
 
     val (repos) = Class.forName("ConfigKt").getResourceAsStream("config.yml").use {
         mapper.readValue(it, ConfigDto::class.java)
@@ -19,13 +20,14 @@ fun loadGithubConfig(): List<GithubConfig> {
             "content-type" to "application/json")
 
     return repos.map {
-        GithubConfig(it, label, headers)
+        GithubConfig(it, label, priority, headers)
     }
 }
 
 data class GithubConfig(
     val baseUrl: String,
     val label: String,
+    val priority: String,
     val headers: Map<String, String>
 )
 

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -8,7 +8,7 @@ fun loadGithubConfig(): List<GithubConfig> {
 
     val basic = System.getenv("GITHUB_USER_TOKEN") ?: throw Exception("Missing GITHUB_USER_TOKEN env variable")
     val label = System.getenv("AUTOMERGE_LABEL") ?: "Automerge"
-    val priority = System.getenv("PRIORITY_LABEL") ?: "Priority"
+    val priority = System.getenv("PRIORITY_LABEL") ?: "Priority Automerge"
 
     val (repos) = Class.forName("ConfigKt").getResourceAsStream("config.yml").use {
         mapper.readValue(it, ConfigDto::class.java)

--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -67,6 +67,7 @@ class GithubService(config: GithubConfig) {
     private val baseUrl = config.baseUrl
     private val headers = config.headers
     private val label = config.label
+    private val priority = config.priority
 
     /**
      * Return the oldest pull request with the specified automerge label
@@ -93,7 +94,7 @@ class GithubService(config: GithubConfig) {
      * @param pull the pull request to check
      * @return true if the pull request has the specified priority label
      */
-    private fun priorityRequest(pull: Pull) = pull.labels.any { it.name == "priority" }
+    private fun priorityRequest(pull: Pull) = pull.labels.any { it.name == priority }
 
     /**
      * Determine if a given pull request has the specified automerge label

--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -82,10 +82,18 @@ class GithubService(config: GithubConfig) {
             }
             is Result.Success -> {
                 val pulls: List<Pull> = mapper.readValue(result.get())
-                pulls.lastOrNull(::labeledRequest)
+                val labeledPulls = pulls.filter(::labeledRequest)
+                labeledPulls.lastOrNull(::priorityRequest) ?: labeledPulls.lastOrNull()
             }
         }
     }
+
+    /**
+     * Determine if a given pull request has the specified priority label
+     * @param pull the pull request to check
+     * @return true if the pull request has the specified priority label
+     */
+    private fun priorityRequest(pull: Pull) = pull.labels.any { it.name == "priority" }
 
     /**
      * Determine if a given pull request has the specified automerge label

--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -83,8 +83,7 @@ class GithubService(config: GithubConfig) {
             }
             is Result.Success -> {
                 val pulls: List<Pull> = mapper.readValue(result.get())
-                val labeledPulls = pulls.filter(::labeledRequest)
-                labeledPulls.lastOrNull(::priorityRequest) ?: labeledPulls.lastOrNull()
+                pulls.lastOrNull(::priorityRequest) ?: pulls.lastOrNull(::labeledRequest)
             }
         }
     }

--- a/src/test/kotlin/GithubServiceTest.kt
+++ b/src/test/kotlin/GithubServiceTest.kt
@@ -13,7 +13,7 @@ class GithubServiceTest {
             "authorization" to "Bearer foo",
             "accept" to "application/vnd.github.v3+json, application/vnd.github.antiope-preview+json",
             "content-type" to "application/json")
-    private val config = GithubConfig("http://foo.test/bar", "Automerge", headers)
+    private val config = GithubConfig("http://foo.test/bar", "Automerge", "Priority", headers)
     private val service = GithubService(config)
     private val client = mockk<Client>()
 
@@ -26,6 +26,17 @@ class GithubServiceTest {
             mockRequest(200, "OK", listOf(newestPull, oldestPull))
             val pull = service.getOldestLabeledRequest()
             assertThat(pull).isEqualTo(oldestPull)
+        }
+
+        @Test
+        fun `Get a pull request with the priority label`() {
+            val oldestPull = generateSamplePull(1)
+            val priorityPull = Pull(2, 2, "Test PR", "",
+                    listOf(Label("Automerge"), Label("Priority")), Branch("", ""), Branch("", ""))
+            val newestPull = generateSamplePull(3)
+            mockRequest(200, "OK", listOf(newestPull, priorityPull, oldestPull))
+            val pull = service.getOldestLabeledRequest()
+            assertThat(pull).isEqualTo(priorityPull)
         }
 
         @Test

--- a/src/test/kotlin/GithubServiceTest.kt
+++ b/src/test/kotlin/GithubServiceTest.kt
@@ -13,7 +13,7 @@ class GithubServiceTest {
             "authorization" to "Bearer foo",
             "accept" to "application/vnd.github.v3+json, application/vnd.github.antiope-preview+json",
             "content-type" to "application/json")
-    private val config = GithubConfig("http://foo.test/bar", "Automerge", "Priority", headers)
+    private val config = GithubConfig("http://foo.test/bar", "Automerge", "Priority Automerge", headers)
     private val service = GithubService(config)
     private val client = mockk<Client>()
 
@@ -32,7 +32,7 @@ class GithubServiceTest {
         fun `Get a pull request with the priority label`() {
             val oldestPull = generateSamplePull(1)
             val priorityPull = Pull(2, 2, "Test PR", "",
-                    listOf(Label("Automerge"), Label("Priority")), Branch("", ""), Branch("", ""))
+                    listOf(Label("Priority Automerge")), Branch("", ""), Branch("", ""))
             val newestPull = generateSamplePull(3)
             mockRequest(200, "OK", listOf(newestPull, priorityPull, oldestPull))
             val pull = service.getOldestLabeledRequest()


### PR DESCRIPTION
Closes: #37 

Added a priority label. (Configurable as an ENV variable, but it is "Priority Automerge" by default). This allows users to tag a bunch of PRs with "Automerge", but if they want something to go in sooner than oldest-first, they can tag it with "Priority Automerge" and it will take precedence. 