### PR TITLE
Remove priority label when there is a problem

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -61,8 +61,8 @@ private fun executeAutomerge(service: GithubService) {
             MergeState.CLEAN -> service.squashMerge(pull)
             MergeState.BEHIND -> service.updateBranch(pull)
             MergeState.BLOCKED -> service.assessStatusAndChecks(pull)
-            MergeState.UNMERGEABLE -> service.removeLabel(pull, LabelRemovalReason.MERGE_CONFLICTS)
-            MergeState.BAD -> service.removeLabel(pull)
+            MergeState.UNMERGEABLE -> service.removeLabels(pull, LabelRemovalReason.MERGE_CONFLICTS)
+            MergeState.BAD -> service.removeLabels(pull)
             MergeState.WAITING -> Unit // Do nothing
         }
     }


### PR DESCRIPTION
Conditionally remove each label if they exist. (Basically just preventing a 404 when the application tries to remove a label that's not there. Like if it is trying to remove the `Automerge` label when the `Priority Automerge` label is on the PR) 