### PR TITLE
Remove label on optional status failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ take precedence in the merge order.
 (Optional) Set the `MERGE_TYPE` environment variable to your desired merge type (Valid options are "merge", "squash",
  and "rebase"). This will determine the type of merge that is performed when merging pull requests. By default, "squash" 
  will be used
+ 
+(Optional) Set the `OPTIONAL_STATUSES` environment variable to true if you want to have the bot merge your pull requests
+if there is a failing status check that is not required. By default, the bot will remove the label and leave 
+a comment
 
 Replace the repository url in the [config.yml](src/main/resources/config.yml) with the information relative to your 
 project (i.e. a list of the urls to as many repos as you want to run it across in parallel).

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ take precedence in the merge order.
  and "rebase"). This will determine the type of merge that is performed when merging pull requests. By default, "squash" 
  will be used
  
-(Optional) Set the `OPTIONAL_STATUSES` environment variable to true if you want to have the bot merge your pull requests
-if there is a failing status check that is not required. By default, the bot will remove the label and leave 
-a comment
+(Optional) Set the `OPTIONAL_STATUSES` environment variable to `true` if you want to have the bot merge your pull requests
+in the event of a failing optional status. If unspecified, the bot will remove the label and leave a comment.
 
 Replace the repository url in the [config.yml](src/main/resources/config.yml) with the information relative to your 
 project (i.e. a list of the urls to as many repos as you want to run it across in parallel).

--- a/src/main/kotlin/Comments.kt
+++ b/src/main/kotlin/Comments.kt
@@ -21,7 +21,7 @@ Uh oh! It looks like there was a problem trying to automerge this pull request.
 It seems likely that this is due to a cancelled or failing non-required status check. Take a look at your statuses and
  get them passing before reapplying the automerge label.
 
-Alternatively, you can set the `OPTIONAL_STATUSES` environment variable to true to ignore optional statuses
+Alternatively, you can set the `OPTIONAL_STATUSES` environment variable to `true` to ignore optional statuses
 """
 
 const val LABEL_REMOVAL_MERGE_CONFLICTS = """

--- a/src/main/kotlin/Comments.kt
+++ b/src/main/kotlin/Comments.kt
@@ -18,7 +18,7 @@ It seems likely that this is due to a cancelled or failing status check. Take a 
 const val LABEL_REMOVAL_OPTIONAL_CHECKS = """
 Uh oh! It looks like there was a problem trying to automerge this pull request.
 
-It seems likely that this is due to a cancelled or failing optional status check. Take a look at your statuses and
+It seems likely that this is due to a cancelled or failing non-required status check. Take a look at your statuses and
  get them passing before reapplying the automerge label.
 
 Alternatively, you can set the `OPTIONAL_STATUSES` environment variable to true to ignore optional statuses

--- a/src/main/kotlin/Comments.kt
+++ b/src/main/kotlin/Comments.kt
@@ -18,8 +18,8 @@ It seems likely that this is due to a cancelled or failing status check. Take a 
 const val LABEL_REMOVAL_OPTIONAL_CHECKS = """
 Uh oh! It looks like there was a problem trying to automerge this pull request.
 
-It seems likely that this is due to a cancelled or failing non-required status check. Take a look at your statuses and
- get them passing before reapplying the automerge label.
+It seems likely that this is due to a cancelled or failing non-required status check. Take a look at your
+ statuses and get them passing before reapplying the automerge label.
 
 Alternatively, you can set the `OPTIONAL_STATUSES` environment variable to `true` to ignore optional statuses
 """

--- a/src/main/kotlin/Comments.kt
+++ b/src/main/kotlin/Comments.kt
@@ -15,6 +15,15 @@ It seems likely that this is due to a cancelled or failing status check. Take a 
  get them passing before reapplying the automerge label.
 """
 
+const val LABEL_REMOVAL_OPTIONAL_CHECKS = """
+Uh oh! It looks like there was a problem trying to automerge this pull request.
+
+It seems likely that this is due to a cancelled or failing optional status check. Take a look at your statuses and
+ get them passing before reapplying the automerge label.
+
+Alternatively, you can set the `OPTIONAL_STATUSES` environment variable to true to ignore optional statuses
+"""
+
 const val LABEL_REMOVAL_MERGE_CONFLICTS = """
 Uh oh! It looks like there was a problem trying to automerge this pull request.
 

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -16,6 +16,7 @@ fun loadGithubConfig(): List<GithubConfig> {
     val label = System.getenv("AUTOMERGE_LABEL") ?: "Automerge"
     val priority = System.getenv("PRIORITY_LABEL") ?: "Priority Automerge"
     val mergeType = System.getenv("MERGE_TYPE") ?: "squash"
+    val optionalStatuses = System.getenv("OPTIONAL_STATUSES").toBoolean()
 
     listOf("squash", "merge", "rebase").any { it == mergeType } ||
             throw IllegalArgumentException("Bad MERGE_TYPE env variable")
@@ -30,7 +31,7 @@ fun loadGithubConfig(): List<GithubConfig> {
             "content-type" to "application/json")
 
     return repos.map {
-        GithubConfig(it, label, priority, mergeType, headers)
+        GithubConfig(it, label, priority, mergeType, headers, optionalStatuses)
     }
 }
 
@@ -48,7 +49,8 @@ data class GithubConfig(
     val label: String,
     val priority: String,
     val mergeType: String,
-    val headers: Map<String, String>
+    val headers: Map<String, String>,
+    val optionalStatuses: Boolean
 )
 
 /**

--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -159,15 +159,17 @@ class GithubService(private val config: GithubConfig) {
     }
 
     /**
-     * Remove the label if there are any failing statuses or checks.
+     * If environment variable is set, merge the pull request; Otherwise, remove the label if there are any
+     * failing statuses or checks or keep waiting.
      *
      * @param pull the pull request to assess
      */
-    fun removeLabelOrWait(pull: Pull) {
-        if (!optionalStatuses) {
-            return
+    fun handleUnstableStatus(pull: Pull) {
+        if (optionalStatuses) {
+            merge(pull)
+        } else {
+            StatusService(config).removeLabelOrWait(pull)
         }
-        StatusService(config).removeLabelOrWait(pull)
     }
 
     /**

--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -158,11 +158,16 @@ class GithubService(private val config: GithubConfig) {
         }
     }
 
+    /**
+     * Remove the label if there are any failing statuses or checks.
+     *
+     * @param pull the pull request to assess
+     */
     fun removeLabelOrWait(pull: Pull) {
         if (!optionalStatuses) {
             return
         }
-        // else, check if there are any failing statuses. If there are, remove label and comment, otherwise return
+        StatusService(config).removeLabelOrWait(pull)
     }
 
     /**

--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -38,6 +38,7 @@ class GithubService(private val config: GithubConfig) {
     private val priority = config.priority
     private val mergeType = config.mergeType
     private val http = Http(headers)
+    private val optionalStatuses = config.optionalStatuses
 
     /**
      * Return the oldest pull request with the specified automerge label.
@@ -99,7 +100,7 @@ class GithubService(private val config: GithubConfig) {
             "clean" -> MergeState.CLEAN
             "blocked" -> MergeState.BLOCKED
             "has_hooks" -> MergeState.WAITING
-            "unstable" -> MergeState.WAITING
+            "unstable" -> MergeState.UNSTABLE
             "unknown" -> MergeState.WAITING
             else -> MergeState.BAD
         }
@@ -155,6 +156,13 @@ class GithubService(private val config: GithubConfig) {
             is Result.Failure -> logFailure(result)
             is Result.Success -> logger.info { "Successfully updating branch for PR: ${pull.title}" }
         }
+    }
+
+    fun removeLabelOrWait(pull: Pull) {
+        if (!optionalStatuses) {
+            return
+        }
+        // else, check if there are any failing statuses. If there are, remove label and comment, otherwise return
     }
 
     /**

--- a/src/main/kotlin/GithubModels.kt
+++ b/src/main/kotlin/GithubModels.kt
@@ -9,6 +9,7 @@ enum class MergeState {
     BEHIND,
     BLOCKED,
     WAITING,
+    UNSTABLE,
     UNMERGEABLE,
     BAD
 }

--- a/src/main/kotlin/GithubModels.kt
+++ b/src/main/kotlin/GithubModels.kt
@@ -29,6 +29,7 @@ enum class StatusState {
 enum class LabelRemovalReason {
     DEFAULT,
     STATUS_CHECKS,
+    OPTIONAL_CHECKS,
     MERGE_CONFLICTS,
     OUTSTANDING_REVIEWS
 }

--- a/src/main/kotlin/LabelService.kt
+++ b/src/main/kotlin/LabelService.kt
@@ -58,6 +58,7 @@ class LabelService(config: GithubConfig) {
             LabelRemovalReason.STATUS_CHECKS -> postComment(pull, LABEL_REMOVAL_STATUS_CHECKS)
             LabelRemovalReason.MERGE_CONFLICTS -> postComment(pull, LABEL_REMOVAL_MERGE_CONFLICTS)
             LabelRemovalReason.OUTSTANDING_REVIEWS -> postComment(pull, LABEL_REMOVAL_OUTSTANDING_REVIEWS)
+            LabelRemovalReason.OPTIONAL_CHECKS -> postComment(pull, LABEL_REMOVAL_OPTIONAL_CHECKS)
         }
     }
 

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -51,7 +51,7 @@ private fun executeAutomerge(service: GithubService) {
             MergeState.BLOCKED -> service.assessStatusAndChecks(pull)
             MergeState.UNMERGEABLE -> service.removeLabels(pull, LabelRemovalReason.MERGE_CONFLICTS)
             MergeState.BAD -> service.removeLabels(pull)
-            MergeState.UNSTABLE -> Unit // Do nothing TODO: Do something
+            MergeState.UNSTABLE -> service.removeLabelOrWait(pull)
             MergeState.WAITING -> Unit // Do nothing
         }
     }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -51,6 +51,7 @@ private fun executeAutomerge(service: GithubService) {
             MergeState.BLOCKED -> service.assessStatusAndChecks(pull)
             MergeState.UNMERGEABLE -> service.removeLabels(pull, LabelRemovalReason.MERGE_CONFLICTS)
             MergeState.BAD -> service.removeLabels(pull)
+            MergeState.UNSTABLE -> Unit // Do nothing TODO: Do something
             MergeState.WAITING -> Unit // Do nothing
         }
     }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -51,7 +51,7 @@ private fun executeAutomerge(service: GithubService) {
             MergeState.BLOCKED -> service.assessStatusAndChecks(pull)
             MergeState.UNMERGEABLE -> service.removeLabels(pull, LabelRemovalReason.MERGE_CONFLICTS)
             MergeState.BAD -> service.removeLabels(pull)
-            MergeState.UNSTABLE -> service.removeLabelOrWait(pull)
+            MergeState.UNSTABLE -> service.handleUnstableStatus(pull)
             MergeState.WAITING -> Unit // Do nothing
         }
     }

--- a/src/main/kotlin/StatusService.kt
+++ b/src/main/kotlin/StatusService.kt
@@ -46,11 +46,10 @@ class StatusService(private val config: GithubConfig) {
         when {
             checks == null -> Unit
             status == null -> Unit
-            else -> {
+            else ->
                 if (status.values.map { statusState(it) }.plus(checks.values.map { checkState(it) }).any(::failure)) {
                     removeLabels(pull, LabelRemovalReason.OPTIONAL_CHECKS)
                 }
-            }
         }
     }
 

--- a/src/main/kotlin/StatusService.kt
+++ b/src/main/kotlin/StatusService.kt
@@ -34,6 +34,28 @@ class StatusService(private val config: GithubConfig) {
         }
     }
 
+    /**
+     * Remove the label if there are any failing statuses or checks. If this function is called,
+     * it is likely an optional status that will be failing.
+     *
+     * @param pull the pull request to assess
+     */
+    fun removeLabelOrWait(pull: Pull) {
+        val checks = getStatusOrChecks<Check, StatusCheck>(pull, SummaryType.CHECK_RUNS)
+        val status = getStatusOrChecks<Status, StatusItem>(pull, SummaryType.STATUS)
+        when {
+            checks == null -> Unit
+            status == null -> Unit
+            else -> {
+                if (status.values.map { statusState(it) }.plus(checks.values.map { checkState(it) }).any(::failure)) {
+                    removeLabels(pull, LabelRemovalReason.OPTIONAL_CHECKS)
+                }
+            }
+        }
+    }
+
+    private fun failure(status: StatusState) = status == StatusState.FAILURE
+
     private fun handleCompletedStatuses(
         pull: Pull,
         required: List<String>,

--- a/src/test/kotlin/GithubServiceTest.kt
+++ b/src/test/kotlin/GithubServiceTest.kt
@@ -101,7 +101,7 @@ class GithubServiceTest {
         fun `Pull request with unstable status returns waiting state`() {
             mockRequest(200, "OK", MergeStatus(1, true, "unstable"))
             val status = service.getReviewStatus(generateSamplePull(1))
-            assertThat(status).isEqualTo(MergeState.WAITING)
+            assertThat(status).isEqualTo(MergeState.UNSTABLE)
         }
 
         @Test

--- a/src/test/kotlin/GithubServiceTest.kt
+++ b/src/test/kotlin/GithubServiceTest.kt
@@ -19,7 +19,7 @@ class GithubServiceTest {
             "accept" to "application/vnd.github.v3+json, application/vnd.github.antiope-preview+json",
             "content-type" to "application/json")
     private val baseUrl = "http://foo.test/bar"
-    private val config = GithubConfig(baseUrl, "Automerge", "Priority Automerge", "squash", headers, true)
+    private val config = GithubConfig(baseUrl, "Automerge", "Priority Automerge", "squash", headers, false)
     private val service = GithubService(config)
     private val client = mockk<Client>()
 
@@ -244,7 +244,7 @@ class GithubServiceTest {
                             checksUrl to MockResponse(200, "OK", checkRuns)
                     )
             )
-            service.removeLabelOrWait(pull)
+            service.handleUnstableStatus(pull)
             assertThat(mockClient.getNumberOfCalls(checksUrl)).isEqualTo(1)
             assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
 
@@ -264,7 +264,7 @@ class GithubServiceTest {
                             checksUrl to MockResponse(404, "Not Found")
                     )
             )
-            service.removeLabelOrWait(pull)
+            service.handleUnstableStatus(pull)
             assertThat(mockClient.getNumberOfCalls(checksUrl)).isEqualTo(1)
             assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
 
@@ -288,7 +288,7 @@ class GithubServiceTest {
                             checksUrl to MockResponse(200, "OK", checkRuns)
                     )
             )
-            service.removeLabelOrWait(pull)
+            service.handleUnstableStatus(pull)
             assertThat(mockClient.getNumberOfCalls(checksUrl)).isEqualTo(1)
             assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
 

--- a/src/test/kotlin/GithubServiceTest.kt
+++ b/src/test/kotlin/GithubServiceTest.kt
@@ -19,7 +19,7 @@ class GithubServiceTest {
             "accept" to "application/vnd.github.v3+json, application/vnd.github.antiope-preview+json",
             "content-type" to "application/json")
     private val baseUrl = "http://foo.test/bar"
-    private val config = GithubConfig(baseUrl, "Automerge", "Priority Automerge", "squash", headers)
+    private val config = GithubConfig(baseUrl, "Automerge", "Priority Automerge", "squash", headers, false)
     private val service = GithubService(config)
     private val client = mockk<Client>()
 

--- a/src/test/kotlin/GithubServiceTest.kt
+++ b/src/test/kotlin/GithubServiceTest.kt
@@ -19,7 +19,7 @@ class GithubServiceTest {
             "accept" to "application/vnd.github.v3+json, application/vnd.github.antiope-preview+json",
             "content-type" to "application/json")
     private val baseUrl = "http://foo.test/bar"
-    private val config = GithubConfig(baseUrl, "Automerge", "Priority Automerge", "squash", headers, false)
+    private val config = GithubConfig(baseUrl, "Automerge", "Priority Automerge", "squash", headers, true)
     private val service = GithubService(config)
     private val client = mockk<Client>()
 
@@ -226,6 +226,75 @@ class GithubServiceTest {
             assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
 
             verify(exactly = 0) { anyConstructed<LabelService>().removeLabels(pull, any()) }
+        }
+    }
+
+    @Nested
+    inner class RemoveLabelOrWait {
+        @Test
+        fun `Error getting statuses results in nothing happening`() {
+            val pull = generateSamplePull(200)
+            mockkConstructor(LabelService::class)
+            val checkRuns = Check(1, listOf(StatusCheck("completed", "Foo - CI", "success")))
+            val statusUrl = "$baseUrl/$COMMITS/${pull.head.sha}/${SummaryType.STATUS.route}"
+            val checksUrl = "$baseUrl/$COMMITS/${pull.head.sha}/${SummaryType.CHECK_RUNS.route}"
+            val mockClient = mockRequests(
+                    mapOf(
+                            statusUrl to MockResponse(404, "Not Found"),
+                            checksUrl to MockResponse(200, "OK", checkRuns)
+                    )
+            )
+            service.removeLabelOrWait(pull)
+            assertThat(mockClient.getNumberOfCalls(checksUrl)).isEqualTo(1)
+            assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
+
+            verify(exactly = 0) { anyConstructed<LabelService>().removeLabels(pull, any()) }
+        }
+
+        @Test
+        fun `Error getting checks results in nothing happening`() {
+            val pull = generateSamplePull(200)
+            mockkConstructor(LabelService::class)
+            val status = Status("Success", 1, listOf(StatusItem("pending", null, "Status - Check")))
+            val statusUrl = "$baseUrl/$COMMITS/${pull.head.sha}/${SummaryType.STATUS.route}"
+            val checksUrl = "$baseUrl/$COMMITS/${pull.head.sha}/${SummaryType.CHECK_RUNS.route}"
+            val mockClient = mockRequests(
+                    mapOf(
+                            statusUrl to MockResponse(200, "OK", status),
+                            checksUrl to MockResponse(404, "Not Found")
+                    )
+            )
+            service.removeLabelOrWait(pull)
+            assertThat(mockClient.getNumberOfCalls(checksUrl)).isEqualTo(1)
+            assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
+
+            verify(exactly = 0) { anyConstructed<LabelService>().removeLabels(pull, any()) }
+        }
+
+        @Test
+        fun `Remove label if any statuses are failing`() {
+            val pull = generateSamplePull(200)
+            mockkConstructor(LabelService::class)
+            every {
+                anyConstructed<LabelService>().removeLabels(pull, LabelRemovalReason.OPTIONAL_CHECKS)
+            } returns Unit
+            val status = Status("Success", 1, listOf(StatusItem("pending", null, "Status - Check")))
+            val checkRuns = Check(1, listOf(StatusCheck("completed", "Foo - CI", "failure")))
+            val statusUrl = "$baseUrl/$COMMITS/${pull.head.sha}/${SummaryType.STATUS.route}"
+            val checksUrl = "$baseUrl/$COMMITS/${pull.head.sha}/${SummaryType.CHECK_RUNS.route}"
+            val mockClient = mockRequests(
+                    mapOf(
+                            statusUrl to MockResponse(200, "OK", status),
+                            checksUrl to MockResponse(200, "OK", checkRuns)
+                    )
+            )
+            service.removeLabelOrWait(pull)
+            assertThat(mockClient.getNumberOfCalls(checksUrl)).isEqualTo(1)
+            assertThat(mockClient.getNumberOfCalls(statusUrl)).isEqualTo(1)
+
+            verify(exactly = 1) {
+                anyConstructed<LabelService>().removeLabels(pull, LabelRemovalReason.OPTIONAL_CHECKS)
+            }
         }
     }
 


### PR DESCRIPTION
Closes: #12 

This change adds an environment variable `OPTIONAL_STATUSES` which is used to determine whether the bot should merge with failing optional statuses, or if it should remove the label on optional status failures. By default, it will remove the label on non-required status failures. 