### PR TITLE
Merge delay

### DIFF
--- a/src/main/kotlin/Github.kt
+++ b/src/main/kotlin/Github.kt
@@ -129,6 +129,7 @@ class GithubService(private val config: GithubConfig) {
             is Result.Success -> {
                 logger.info { "Successfully merged ${pull.title}!" }
                 deleteBranch(pull)
+                Thread.sleep(200)
             }
         }
         return true


### PR DESCRIPTION
Adding a small sleep function after successfully merging so that subsequent requests give github enough time to update properly. Right now after merging a PR, we immediately request the status of the next PR and it's sometimes coming back as "Unknown" Hopefully this will help with that. 